### PR TITLE
Fix BASH_SOURCE unbound variable error in universal installer

### DIFF
--- a/install-emad-universal.sh
+++ b/install-emad-universal.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 # EMAD Universal Intelligent Installation Script
-# Version: 2.0.0 (July 2025)
+# Version: 2.0.1 (July 2025)
 # Supports: All major platforms with intelligent adaptation
-# Usage: curl -sSL https://install.emad.dev | bash
+# Usage: curl -sSL https://raw.githubusercontent.com/huggingfacer04/EMAD/main/install-emad-universal.sh | bash
+# Fixed: BASH_SOURCE unbound variable error when piped from curl
 
 set -euo pipefail
 
 # Global Configuration
-readonly EMAD_VERSION="2.0.0"
+readonly EMAD_VERSION="2.0.1"
 readonly EMAD_REPO="https://github.com/huggingfacer04/EMAD"
 readonly EMAD_API_BASE="https://api.emad.dev"
 readonly EMAD_CDN="https://cdn.emad.dev"
@@ -680,7 +681,13 @@ main() {
     echo "Support: https://github.com/huggingfacer04/EMAD/discussions"
 }
 
-# Execute main function if script is run directly
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# Execute main function if script is run directly or piped from curl
+# Handle both direct execution and piped execution (curl | bash)
+# BASH_SOURCE[0] is undefined when script is piped from curl, so we check for both conditions
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" ]]; then
+    # Ensure we're in a reasonable working directory for piped execution
+    if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ "$(pwd)" == "/" ]]; then
+        cd "$HOME" || cd /tmp
+    fi
     main "$@"
 fi


### PR DESCRIPTION
## Problem

The EMAD universal installer script (`install-emad-universal.sh`) was failing with a "BASH_SOURCE[0]: unbound variable" error when executed via `curl | bash`. This caused installation to exit with code 1 at line 684, preventing successful deployment.

## Root Cause

When a script is executed via `curl | bash`, the `BASH_SOURCE` array is not populated because the script is read from stdin rather than from a file. The original condition `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]` would fail due to the `set -euo pipefail` setting treating undefined variables as errors.

## Solution

### Changes Made

1. **Fixed execution condition** (lines 687-693):
   - Changed from: `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then`
   - Changed to: `if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" ]]; then`
   - Uses defensive programming with `${VAR:-}` syntax to handle undefined variables
   - Checks for both direct execution and piped execution scenarios

2. **Added working directory safety** (lines 689-691):
   - When script is piped and current directory is root, change to a safer directory
   - Prevents potential issues with file operations in restricted directories

3. **Updated version and documentation**:
   - Version bumped from 2.0.0 to 2.0.1
   - Added fix documentation in header comments
   - Corrected usage URL to match actual GitHub repository path

## Testing

✅ **Comprehensive testing performed:**
- Script syntax validation (`bash -n`)
- Direct execution simulation
- Piped execution simulation (`curl | bash`)
- Function testing with actual environment detection
- Python detection and project type detection verified

## Benefits

- ✅ **Resolves BASH_SOURCE[0] unbound variable error**
- ✅ **Works correctly when piped from curl**
- ✅ **Maintains cross-platform compatibility** (Linux, macOS, Windows via WSL/Git Bash)
- ✅ **Preserves all existing self-healing functionality**
- ✅ **Maintains 95%+ success rate target**
- ✅ **Supports corporate/air-gapped environments**
- ✅ **Proper error handling and logging preserved**

## Installation Command

The fixed script now works correctly with:
```bash
curl -sSL https://raw.githubusercontent.com/huggingfacer04/EMAD/main/install-emad-universal.sh | bash
```

## Impact

This is a **critical bug fix** that enables the universal installer to work as intended across all deployment scenarios. The fix is minimal, targeted, and maintains backward compatibility while resolving the installation failure.

---

**Fixes:** Installation exits with code 1 at line 684  
**Type:** Bug Fix  
**Priority:** High  
**Tested:** ✅ Comprehensive validation completed

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author